### PR TITLE
Improve thread safety of subclass ThreadLocalSecurityProvider.

### DIFF
--- a/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/ThreadLocalSecurityProvider.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/ThreadLocalSecurityProvider.java
@@ -66,6 +66,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         return PROVIDER.get();
     }
 
+    @Override
     public synchronized void clear() {
         Provider p = getProvider();
         if (p != null) {
@@ -73,6 +74,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized void load(InputStream inStream) throws IOException {
         Provider p = getProvider();
         if (p != null) {
@@ -80,6 +82,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized void putAll(Map<?, ?> t) {
         Provider p = getProvider();
         if (p != null) {
@@ -87,6 +90,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized Set<Map.Entry<Object, Object>> entrySet() {
         Provider p = getProvider();
         if (p != null) {
@@ -96,6 +100,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public Set<Object> keySet() {
         Provider p = getProvider();
         if (p != null) {
@@ -105,6 +110,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public Collection<Object> values() {
         Provider p = getProvider();
         if (p != null) {
@@ -114,6 +120,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized Object put(Object key, Object value) {
         Provider p = getProvider();
         if (p != null) {
@@ -123,6 +130,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized Object remove(Object key) {
         Provider p = getProvider();
         if (p != null) {
@@ -132,6 +140,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public Object get(Object key) {
         Provider p = getProvider();
         if (p != null) {
@@ -141,6 +150,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public Enumeration<Object> keys() {
         Provider p = getProvider();
         if (p != null) {
@@ -150,6 +160,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public Enumeration<Object> elements() {
         Provider p = getProvider();
         if (p != null) {
@@ -159,6 +170,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public String getProperty(String key) {
         Provider p = getProvider();
         if (p != null) {
@@ -168,6 +180,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized Service getService(String type, String algorithm) {
         Provider p = getProvider();
         if (p != null) {
@@ -177,6 +190,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
+    @Override
     public synchronized Set<Service> getServices() {
         Provider p = getProvider();
         if (p != null) {

--- a/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/ThreadLocalSecurityProvider.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/ThreadLocalSecurityProvider.java
@@ -37,7 +37,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
 
     public static synchronized void install() {
         Security.insertProviderAt(new ThreadLocalSecurityProvider(),
-                                  Security.getProviders().length);
+                Security.getProviders().length);
         installed = true;
     }
 
@@ -66,28 +66,28 @@ public final class ThreadLocalSecurityProvider extends Provider {
         return PROVIDER.get();
     }
 
-    public void clear() {
+    public synchronized void clear() {
         Provider p = getProvider();
         if (p != null) {
             p.clear();
         }
     }
 
-    public void load(InputStream inStream) throws IOException {
+    public synchronized void load(InputStream inStream) throws IOException {
         Provider p = getProvider();
         if (p != null) {
             p.load(inStream);
         }
     }
 
-    public void putAll(Map<?, ?> t) {
+    public synchronized void putAll(Map<?, ?> t) {
         Provider p = getProvider();
         if (p != null) {
             p.putAll(t);
         }
     }
 
-    public Set<Map.Entry<Object, Object>> entrySet() {
+    public synchronized Set<Map.Entry<Object, Object>> entrySet() {
         Provider p = getProvider();
         if (p != null) {
             return p.entrySet();
@@ -114,7 +114,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
-    public Object put(Object key, Object value) {
+    public synchronized Object put(Object key, Object value) {
         Provider p = getProvider();
         if (p != null) {
             return p.put(key, value);
@@ -123,7 +123,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
-    public Object remove(Object key) {
+    public synchronized Object remove(Object key) {
         Provider p = getProvider();
         if (p != null) {
             return p.remove(key);
@@ -168,7 +168,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
-    public Service getService(String type, String algorithm) {
+    public synchronized Service getService(String type, String algorithm) {
         Provider p = getProvider();
         if (p != null) {
             return p.getService(type, algorithm);
@@ -177,7 +177,7 @@ public final class ThreadLocalSecurityProvider extends Provider {
         }
     }
 
-    public Set<Service> getServices() {
+    public synchronized Set<Service> getServices() {
         Provider p = getProvider();
         if (p != null) {
             return p.getServices();


### PR DESCRIPTION
- If a synchronized method is overridden in a subclass, the compiler does not require the overriding method to be synchronized. However, if the overriding method is not synchronized, the thread-safety of the subclass may be broken. As for [1]. 

- This PR improves the thread safety of ThreadLocalSecurityProvider by adding the synchronized keywords to the overridden synchronized methods. Fixes some of the alerts in [https://lgtm.com/projects/g/apache/ws-wss4j/alerts/?mode=list](https://lgtm.com/projects/g/apache/ws-wss4j/alerts/?mode=list).

[1] - [https://help.semmle.com/wiki/display/JAVA/Non-synchronized+override+of+synchronized+method](https://help.semmle.com/wiki/display/JAVA/Non-synchronized+override+of+synchronized+method) 
