### PR TITLE
Fix Build Status Icon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://builds.apache.org/view/S-Z/view/WS/job/wss4j-master/badge/icon?subject=Build)](https://builds.apache.org/view/S-Z/view/WS/job/wss4j-master/)
+[![Build Status](https://builds.apache.org/job/webservices/job/Apache%20WSS4J%20-%20master%20JDK11/badge/icon?subject=Build)](https://builds.apache.org/job/webservices/job/Apache%20WSS4J%20-%20master%20JDK11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.wss4j/wss4j/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.wss4j/wss4j)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/apache/ws-wss4j/badge)](https://api.securityscorecards.dev/projects/github.com/apache/ws-wss4j)
 


### PR DESCRIPTION
This fixes URL so build badge for master JDK11 is shown correctly.