### PR TITLE
EncryptedKeyProcessor: make decryptDataRef(s) protected

### DIFF
--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
@@ -505,7 +505,7 @@ public class EncryptedKeyProcessor implements Processor {
     /**
      * Decrypt all data references
      */
-    private List<WSDataRef> decryptDataRefs(Element refList, WSDocInfo docInfo,
+    protected List<WSDataRef> decryptDataRefs(Element refList, WSDocInfo docInfo,
                                             byte[] decryptedBytes, RequestData data
     ) throws WSSecurityException {
         //
@@ -536,7 +536,7 @@ public class EncryptedKeyProcessor implements Processor {
     /**
      * Decrypt an EncryptedData element referenced by dataRefURI
      */
-    private WSDataRef decryptDataRef(
+    protected WSDataRef decryptDataRef(
         Document doc,
         String dataRefURI,
         WSDocInfo docInfo,


### PR DESCRIPTION
When implementing a custom `EncryptedKeyProcessor` and deriving from it, it would be helpful if the methods `decryptDataRef` and `decryptDataRefs` were `protected`.

Deriving the `EncryptedKeyProcessor` is e.g. required for imeplementing key exchange via ECDH-ES, and these two methods can be reused there.