### PR TITLE
Fail build if CVSS score is above 6

### DIFF
--- a/build-tools/dependency-check-suppression.xml
+++ b/build-tools/dependency-check-suppression.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression'
+        xsi:schemaLocation='https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression suppression.xsd'>
+<!--
+    <suppress>
+        <notes><![CDATA[
+        This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum.
+        ]]></notes>
+        <sha1>384FAA82E193D4E4B0546059CA09572654BC3970</sha1>
+        <cve>CVE-2013-1337</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This suppresses all CVE entries that have a score below CVSS 5.
+        ]]></notes>
+        <cvssBelow>5</cvssBelow>
+    </suppress>
+-->
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <buildtools.dir>${basedir}/build-tools</buildtools.dir>
         <maven-owasp-plugin-version>8.2.1</maven-owasp-plugin-version>
-        <project.build.outputTimestamp>2022-10-04T10:59:15Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2022-10-04T11:02:58Z</project.build.outputTimestamp>
     </properties>
 
     <modules>
@@ -322,7 +322,7 @@
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${maven-owasp-plugin-version}</version>
-                 </plugin>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -418,7 +418,6 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>${maven-owasp-plugin-version}</version>
                         <configuration>
                             <failBuildOnCVSS>6</failBuildOnCVSS>
                             <skipProvidedScope>true</skipProvidedScope>
@@ -472,7 +471,6 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>${maven-owasp-plugin-version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <targetJdk>11</targetJdk>
         <maven.compiler.target>11</maven.compiler.target>
         <buildtools.dir>${basedir}/build-tools</buildtools.dir>
-        <maven-owasp-plugin-version>6.5.3</maven-owasp-plugin-version>
+        <maven-owasp-plugin-version>8.2.1</maven-owasp-plugin-version>
         <project.build.outputTimestamp>2022-10-04T10:59:15Z</project.build.outputTimestamp>
     </properties>
 
@@ -322,15 +322,7 @@
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${maven-owasp-plugin-version}</version>
-                    <executions>
-                        <execution>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
+                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -426,6 +418,23 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
+                        <version>${maven-owasp-plugin-version}</version>
+                        <configuration>
+                            <failBuildOnCVSS>6</failBuildOnCVSS>
+                            <skipProvidedScope>true</skipProvidedScope>
+                            <skipRuntimeScope>true</skipRuntimeScope>
+                            <suppressionFiles>
+                                <suppressionFile>${buildtools.dir}/dependency-check-suppression.xml</suppressionFile>
+                            </suppressionFiles>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Moved plugin execution to existing profile :

`dependencycheck`

Exclusion file: build-tools/dependency-check-suppression.xml

**About merge:**
_project.build.outputTimestamp_ changed in my branch to match **master** so there would be no conflict, and there is no actual change to master.



**TESTED** 
mvn compile
mvn site - checked vulnerability report 

Work was tested on wss4j-3.0.0 since often the master artifact dependencies are not published.

On the 3.0.0 version 

1)
`mvn compile`

BUILD SUCCESS

2) 

`mvn -P dependencycheck compile`

BUILD FAILURE

```

[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '6.0': 
[ERROR] 
[ERROR] guava-31.1-jre.jar: CVE-2020-8908(6.2), CVE-2023-2976(6.2)
[ERROR] 
[ERROR] See the dependency-check report for more details.
```

3) 

Reviewed generated site report and it seems to be correct.






