### PR TITLE
[WSS-710] Implementation of the configurations for KeyDerivation functions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,7 +49,7 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <woodstox.version>6.6.1</woodstox.version>
         <xz.version>1.9</xz.version>
-        <xmlsec.version>4.0.2</xmlsec.version>
+        <xmlsec.version>4.0.3-SNAPSHOT</xmlsec.version>
         <xmlunit.version>2.9.1</xmlunit.version>
         <!-- OSGi related properties -->
         <wss4j.osgi.import />

--- a/ws-security-common/src/main/java/org/apache/wss4j/common/ConfigurationConstants.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/ConfigurationConstants.java
@@ -753,6 +753,44 @@ public class ConfigurationConstants {
     public static final String ENC_KEY_AGREEMENT_METHOD = "encryptionKeyAgreementMethod";
 
     /**
+     * Defines the Key Derivation algorithm to derive encryption key used with the keyAgreement method.
+     * The default algorithm is:
+     * "http://www.w3.org/2021/04/xmldsig-more#hkdf"
+     *
+     * <p/>
+     * The application may set this parameter using the following method:
+     * <pre>
+     *      call.setProperty(ConfigurationConstants.ENC_KEY_DERIVATION_FUNCTION,
+     *          WSConstants.KEYDERIVATION_HKDF);
+     * </pre>
+     *
+     */
+    public static final String ENC_KEY_DERIVATION_FUNCTION = "encryptionKeyDerivationFunction";
+
+    /**
+     * Defines the Key Derivation parameters to derive encryption key used with the keyAgreement method. In case the
+     * property value is set  it supersede the ENC_KEY_DERIVATION_FUNCTION value.
+     * The value for the property must implement the <code>org.apache.xml.security.encryption.params.KeyDerivationParameters</code>
+     * interface. Currently, only the <code>org.apache.xml.security.encryption.params.HKDFParams</code> and
+     * <code>org.apache.xml.security.encryption.params.ConcatKDFParams</code>.
+     *
+     *
+     * The application may set this parameter using the following method:
+     * <pre>
+     *     KeyDerivationParameters kdfParams = new ConcatKDFParams(keyBitLen, MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256);
+     *     kdfParams.setAlgorithmId("00363532534541");
+     *     kdfParams.setPartyUInfo("00DFC9DB773C588F8F");
+     *     kdfParams.setPartyVInfo("00DFDA76F7AB09B7C9");
+     *     kdfParams.setSuppPubInfo(null);
+     *     kdfParams.setSuppPrivInfo(null);
+     *
+     *     call.set(ConfigurationConstants.ENC_KEY_DERIVATION_PARAMS,kdfParams);
+     * </pre>
+     *
+     */
+    public static final String ENC_KEY_DERIVATION_PARAMS = "encryptionKeyDerivationParams";
+
+    /**
      * Parameter to define which parts of the request shall be encrypted.
      * <p/>
      * The value of this parameter is a list of semi-colon separated

--- a/ws-security-common/src/main/java/org/apache/wss4j/common/EncryptionActionToken.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/EncryptionActionToken.java
@@ -19,6 +19,8 @@
 package org.apache.wss4j.common;
 
 
+import org.apache.xml.security.encryption.params.KeyDerivationParameters;
+
 /**
  * This class encapsulates configuration for Encryption Actions.
  */
@@ -28,6 +30,8 @@ public class EncryptionActionToken extends SignatureEncryptionActionToken {
     private String mgfAlgorithm;
     private String symmetricAlgorithm;
     private String keyAgreementMethodAlgorithm;
+    private String keyDerivationFunction;
+    private KeyDerivationParameters keyDerivationParameters;
     private String keyTransportAlgorithm;
     private boolean getSymmetricKeyFromCallbackHandler;
 
@@ -55,6 +59,7 @@ public class EncryptionActionToken extends SignatureEncryptionActionToken {
     public void setKeyTransportAlgorithm(String keyTransportAlgorithm) {
         this.keyTransportAlgorithm = keyTransportAlgorithm;
     }
+
     public String getKeyAgreementMethodAlgorithm() {
         return keyAgreementMethodAlgorithm;
     }
@@ -68,5 +73,20 @@ public class EncryptionActionToken extends SignatureEncryptionActionToken {
         this.getSymmetricKeyFromCallbackHandler = getSymmetricKeyFromCallbackHandler;
     }
 
+    public String getKeyDerivationFunction() {
+        return keyDerivationFunction;
+    }
+
+    public void setKeyDerivationFunction(String keyDerivationFunction) {
+        this.keyDerivationFunction = keyDerivationFunction;
+    }
+
+    public KeyDerivationParameters getKeyDerivationParameters() {
+        return keyDerivationParameters;
+    }
+
+    public void setKeyDerivationParameters(KeyDerivationParameters keyDerivationParameters) {
+        this.keyDerivationParameters = keyDerivationParameters;
+    }
 }
 

--- a/ws-security-common/src/main/java/org/apache/wss4j/common/WSS4JConstants.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/WSS4JConstants.java
@@ -116,10 +116,16 @@ public class WSS4JConstants {
             "http://www.w3.org/2001/04/xmlenc#kw-aes256";
     public static final String KEYWRAP_TRIPLEDES =
             "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
-    public static final String KDF_CONCAT =
+    public static final String KEYDERIVATION_CONCATKDF =
             "http://www.w3.org/2009/xmlenc11#ConcatKDF";
+    public static final String KEYDERIVATION_HKDF =
+            "http://www.w3.org/2021/04/xmldsig-more#hkdf";
     public static final String AGREEMENT_METHOD_ECDH_ES =
             "http://www.w3.org/2009/xmlenc11#ECDH-ES";
+    public static final String AGREEMENT_METHOD_X25519 =
+            "http://www.w3.org/2021/04/xmldsig-more#x25519";
+    public static final String AGREEMENT_METHOD_X448 =
+            "http://www.w3.org/2021/04/xmldsig-more#x448";
     public static final String TRIPLE_DES =
         "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
     public static final String AES_128 =

--- a/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/AlgorithmSuiteValidator.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/AlgorithmSuiteValidator.java
@@ -152,6 +152,26 @@ public class AlgorithmSuiteValidator {
         }
     }
 
+    /**
+     * Method to check the Key Derivation algorithm is on the approved list  of the
+     * AlgorithmSuite configuration.
+     * @param keyDerivationFunction the key derivation function to be validated
+     * @throws WSSecurityException if the approved list is not empty and the key
+     * derivation function is not on the list
+     */
+    public void checkKeyDerivationFunction(
+            String keyDerivationFunction
+    ) throws WSSecurityException {
+        Set<String> keyDerivationFunctions = algorithmSuite.getDerivedKeyAlgorithms();
+        if (!keyDerivationFunctions.isEmpty()
+                && !keyDerivationFunctions.contains(keyDerivationFunction)) {
+            LOG.warn(
+                    "The Key derivation function does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
     public void checkSymmetricEncryptionAlgorithm(
         String symmetricAlgorithm
     ) throws WSSecurityException {

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/action/EncryptionAction.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/action/EncryptionAction.java
@@ -61,12 +61,23 @@ public class EncryptionAction implements Action {
         if (encryptionToken.getSymmetricAlgorithm() != null) {
             wsEncrypt.setSymmetricEncAlgorithm(encryptionToken.getSymmetricAlgorithm());
         }
+
         if (encryptionToken.getKeyTransportAlgorithm() != null) {
             wsEncrypt.setKeyEncAlgo(encryptionToken.getKeyTransportAlgorithm());
         }
+
         if (encryptionToken.getKeyAgreementMethodAlgorithm() != null) {
             wsEncrypt.setKeyAgreementMethod(encryptionToken.getKeyAgreementMethodAlgorithm());
         }
+
+        if (encryptionToken.getKeyDerivationFunction() != null) {
+            wsEncrypt.setKeyDerivationMethod(encryptionToken.getKeyDerivationFunction());
+        }
+
+        if (encryptionToken.getKeyDerivationParameters() != null) {
+            wsEncrypt.setKeyDerivationParameters(encryptionToken.getKeyDerivationParameters());
+        }
+
         if (encryptionToken.getDigestAlgorithm() != null) {
             wsEncrypt.setDigestAlgorithm(encryptionToken.getDigestAlgorithm());
         }

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/handler/WSHandler.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/handler/WSHandler.java
@@ -47,6 +47,7 @@ import org.apache.wss4j.common.util.Loader;
 import org.apache.wss4j.dom.message.WSSecHeader;
 import org.apache.wss4j.dom.message.token.SignatureConfirmation;
 import org.apache.wss4j.dom.util.WSSecurityUtil;
+import org.apache.xml.security.encryption.params.KeyDerivationParameters;
 import org.w3c.dom.Document;
 
 /**
@@ -665,6 +666,11 @@ public abstract class WSHandler {
             algorithmSuite.addKeyAgreementMethodAlgorithm(transportAlgorithm);
         }
 
+        String keyDerivationAlgorithm = getString(WSHandlerConstants.ENC_KEY_DERIVATION_FUNCTION, mc);
+        if (keyDerivationAlgorithm != null && !keyDerivationAlgorithm.isEmpty()) {
+            algorithmSuite.addDerivedKeyAlgorithm(keyDerivationAlgorithm);
+        }
+
         reqData.setAlgorithmSuite(algorithmSuite);
     }
 
@@ -717,6 +723,15 @@ public abstract class WSHandler {
         String encKeyAgreementMethod =
                 getString(WSHandlerConstants.ENC_KEY_AGREEMENT_METHOD, mc);
         actionToken.setKeyAgreementMethodAlgorithm(encKeyAgreementMethod);
+
+        String encKeyDerivationAlgorithm =
+                getString(WSHandlerConstants.ENC_KEY_DERIVATION_FUNCTION, mc);
+        actionToken.setKeyDerivationFunction(encKeyDerivationAlgorithm);
+
+        Object obj = getProperty(mc, WSHandlerConstants.ENC_KEY_DERIVATION_PARAMS);
+        if (obj instanceof KeyDerivationParameters) {
+            actionToken.setKeyDerivationParameters((KeyDerivationParameters)obj);
+        }
 
         String derivedKeyReference = getString(WSHandlerConstants.DERIVED_TOKEN_REFERENCE, mc);
         actionToken.setDerivedKeyTokenReference(derivedKeyReference);

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/handler/WSHandler.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/handler/WSHandler.java
@@ -663,7 +663,7 @@ public abstract class WSHandler {
 
         String keyAgreementMethodAlgorithm = getString(WSHandlerConstants.ENC_KEY_AGREEMENT_METHOD, mc);
         if (keyAgreementMethodAlgorithm != null && !keyAgreementMethodAlgorithm.isEmpty()) {
-            algorithmSuite.addKeyAgreementMethodAlgorithm(transportAlgorithm);
+            algorithmSuite.addKeyAgreementMethodAlgorithm(keyAgreementMethodAlgorithm);
         }
 
         String keyDerivationAlgorithm = getString(WSHandlerConstants.ENC_KEY_DERIVATION_FUNCTION, mc);

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
@@ -91,7 +91,7 @@ public class WSSecEncryptedKey extends WSSecBase {
     /**
      * The Key Derivation Parameters for the with the Key keyAgreementMethod
      */
-    KeyDerivationParameters keyDerivationParameters;
+    private KeyDerivationParameters keyDerivationParameters;
 
     /**
      * Digest Algorithm to be used with RSA-OAEP. The default is SHA-1 (which is not
@@ -224,7 +224,7 @@ public class WSSecEncryptedKey extends WSSecBase {
 
             Key kek;
             KeyAgreementParameters dhSpec = null;
-            if (isKeyAgreementMethodNotEmpty(keyAgreementMethod)) {
+            if (isKeyAgreementConfigured(keyAgreementMethod)) {
                 // generate ephemeral keys the key must match receivers keys
                 dhSpec = buildKeyAgreementParameter(remoteCert.getPublicKey());
                 kek = generateEncryptionKey(dhSpec);
@@ -382,7 +382,7 @@ public class WSSecEncryptedKey extends WSSecBase {
             keyInfoElement.setAttributeNS(
                 WSConstants.XMLNS_NS, "xmlns:" + WSConstants.SIG_PREFIX, WSConstants.SIG_NS
             );
-            if (isKeyAgreementMethodNotEmpty(keyAgreementMethod)) {
+            if (isKeyAgreementConfigured(keyAgreementMethod)) {
                 try {
                     AgreementMethodImpl agreementMethod = new AgreementMethodImpl(getDocument(), dhSpec);
                     agreementMethod.getRecipientKeyInfo().addUnknownElement(secToken.getElement());
@@ -401,11 +401,11 @@ public class WSSecEncryptedKey extends WSSecBase {
     }
 
     /**
-     * Method verifies is the key agreement method is not empty
+     * Method verifies is the key agreement method is configured(not empty)
      * @param keyAgreementMethod the key agreement method
      * @return true if the key agreement method is not empty else false
      */
-    private boolean isKeyAgreementMethodNotEmpty(String keyAgreementMethod) {
+    private boolean isKeyAgreementConfigured(String keyAgreementMethod) {
          return keyAgreementMethod != null && !keyAgreementMethod.isEmpty();
     }
 

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
@@ -53,7 +53,6 @@ import javax.xml.crypto.dsig.keyinfo.KeyInfoFactory;
 import javax.xml.crypto.dsig.keyinfo.KeyValue;
 import java.security.*;
 import java.security.cert.X509Certificate;
-import java.util.Random;
 
 /**
  * Builder class to build an EncryptedKey.
@@ -620,7 +619,7 @@ public class WSSecEncryptedKey extends WSSecBase {
                 //   size or with limited entropy) may still make a significant
                 //   contribution to the security of the output keying material
                 byte[] semiRandom = new byte[keyBitLength / 8];
-                new Random().nextBytes(semiRandom);
+                new SecureRandom().nextBytes(semiRandom);
                 return XMLCipherUtil.constructHKDFKeyDerivationParameter(keyBitLength, WSS4JConstants.HMAC_SHA256, semiRandom, null);
             default:
                 throw new WSSecurityException(

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
@@ -419,7 +419,9 @@ public class EncryptedKeyProcessor implements Processor {
                 && WSConstants.ENC_NS.equals(keyInfoChildElement.getNamespaceURI())) {
             String algorithmURI = keyInfoChildElement.getAttributeNS(null, "Algorithm");
             // Only ECDH_ES is supported for AgreementMethod
-            if (!WSConstants.AGREEMENT_METHOD_ECDH_ES.equals(algorithmURI)) {
+            if (!(WSConstants.AGREEMENT_METHOD_ECDH_ES.equals(algorithmURI)
+                || WSConstants.AGREEMENT_METHOD_X25519.equals(algorithmURI)
+                || WSConstants.AGREEMENT_METHOD_X448.equals(algorithmURI))) {
                 throw new WSSecurityException(
                         WSSecurityException.ErrorCode.UNSUPPORTED_ALGORITHM,
                         "unknownAlgorithm", new Object[]{algorithmURI});

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
@@ -35,6 +35,7 @@ import javax.crypto.spec.OAEPParameterSpec;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 
 import org.apache.xml.security.encryption.AgreementMethod;
+import org.apache.xml.security.encryption.KeyDerivationMethod;
 import org.apache.xml.security.encryption.XMLCipherUtil;
 import org.apache.xml.security.encryption.keys.RecipientKeyInfo;
 import org.apache.xml.security.encryption.keys.content.AgreementMethodImpl;
@@ -150,9 +151,11 @@ public class EncryptedKeyProcessor implements Processor {
         PublicKey publicKey = null;
         boolean symmetricKeyWrap = isSymmetricKeyWrap(encryptedKeyTransportMethod);
         AgreementMethod agreementMethod = null;
+        KeyDerivationMethod keyDerivationMethod = null;
         if (isDHKeyWrap) {
             // get key agreement method value
             agreementMethod = getAgreementMethodFromElement(keyInfoChildElement);
+            keyDerivationMethod = getKeyDerivationFunction(agreementMethod);
             //  get the recipient key info element
             keyInfoChildElement = getRecipientKeyInfoChildElement(agreementMethod);
             if (keyInfoChildElement == null) {
@@ -182,6 +185,11 @@ public class EncryptedKeyProcessor implements Processor {
             if (agreementMethod != null) {
                 algorithmSuiteValidator.checkKeyAgreementMethodAlgorithm(
                         agreementMethod.getAlgorithm()
+                );
+            }
+            if (keyDerivationMethod != null) {
+                algorithmSuiteValidator.checkKeyDerivationFunction(
+                        keyDerivationMethod.getAlgorithm()
                 );
             }
         }
@@ -561,6 +569,24 @@ public class EncryptedKeyProcessor implements Processor {
             return strElement;
         } else {
             throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY, "noKeyinfo");
+        }
+    }
+
+    /**
+     * Method retrieved the KeyDerivationMethod child element from the AgreementMethod object.
+     *
+     * @param agreementMethod object containing th KeyDerivationMethod.
+     * @return the {@link KeyDerivationMethod} object or null if no KeyDerivation element is specified in the agreementMethod.
+     * @throws WSSecurityException if KeyDerivationMethod can not be parsed from Element structure.
+     */
+    private KeyDerivationMethod getKeyDerivationFunction(AgreementMethod agreementMethod) throws WSSecurityException {
+        if (agreementMethod == null) {
+            return null;
+        }
+        try {
+            return agreementMethod.getKeyDerivationMethod();
+        } catch (XMLSecurityException ex) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY, ex);
         }
     }
 

--- a/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/EncryptionTest.java
+++ b/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/EncryptionTest.java
@@ -23,6 +23,7 @@ import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.UUID;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -52,8 +53,9 @@ import org.apache.wss4j.dom.handler.WSHandlerConstants;
 import org.apache.wss4j.dom.handler.WSHandlerResult;
 import org.apache.wss4j.dom.str.STRParser.REFERENCE_TYPE;
 import org.apache.wss4j.dom.util.WSSecurityUtil;
-
+import org.apache.xml.security.encryption.params.HKDFParams;
 import org.apache.xml.security.utils.EncryptionConstants;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -102,6 +104,11 @@ public class EncryptionTest {
         key = keyGen.generateKey();
         keyData = key.getEncoded();
         secEngine.setWssConfig(WSSConfig.getNewInstance());
+    }
+
+    @AfterEach
+    public void cleanup() {
+        JDKTestUtils.unregisterAuxiliaryProvider();
     }
 
     /**
@@ -317,23 +324,38 @@ public class EncryptionTest {
 
     /**
      * Test that encrypt and decrypt a WS-Security envelope.
-     * This test uses the ECDSA-ES algorithm to (wrap) the symmetric key.
+     * This test uses the key agreement algorithm to (wrap) the symmetric key with generating KDF with
+     * default parameter
      * <p/>
      *
+     * @param algorithm The key type algorithm
+     * @param certAlias The certificate alias from the configuration defined in wss-ecdh.properties
+     * @param keyAgreementMethod The key agreement method
+     * @param kdfAlgorithm The key derivation method
      * @throws Exception Thrown when there is any problem in signing or verification
      */
     @ParameterizedTest
-    @CsvSource({"xdh, X25519",
-            "xdh, X448",
-            "ec, secp256r1",
-            "ec, secp384r1",
-            "ec, secp521r1",
+    @CsvSource({"xdh, X25519, http://www.w3.org/2021/04/xmldsig-more#x25519, http://www.w3.org/2009/xmlenc11#ConcatKDF",
+            "xdh, X448, http://www.w3.org/2021/04/xmldsig-more#x448, http://www.w3.org/2009/xmlenc11#ConcatKDF",
+            "ec, secp256r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2009/xmlenc11#ConcatKDF",
+            "ec, secp384r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2009/xmlenc11#ConcatKDF",
+            "ec, secp521r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2009/xmlenc11#ConcatKDF",
+            "xdh, X25519, http://www.w3.org/2021/04/xmldsig-more#x25519, http://www.w3.org/2021/04/xmldsig-more#hkdf",
+            "xdh, X448, http://www.w3.org/2021/04/xmldsig-more#x448, http://www.w3.org/2021/04/xmldsig-more#hkdf",
+            "ec, secp256r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2021/04/xmldsig-more#hkdf",
+            "ec, secp384r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2021/04/xmldsig-more#hkdf",
+            "ec, secp521r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2021/04/xmldsig-more#hkdf",
     })
-    public void testEncryptionDecryptionECDSA_ES(String algorithm, String certAlias) throws Exception {
+    public void testEncryptionDecryptionWithKeyAgreementAndDefaultKDF(String algorithm, String certAlias, String keyAgreementMethod, String kdfAlgorithm) throws Exception {
         try {
             if (!JDKTestUtils.isAlgorithmSupportedByJDK(algorithm)) {
-                LOG.info("Add AuxiliaryProvider to execute test with algorithm [{}] and cert alias [{}]", algorithm,  certAlias);
+                LOG.info("Add AuxiliaryProvider to execute test with algorithm [{}] and cert alias [{}]", algorithm, certAlias);
                 Security.addProvider(JDKTestUtils.getAuxiliaryProvider());
+            } else if (JDKTestUtils.getJDKVersion() == 11 && algorithm.equals("xdh")) {
+                // workaround for jdk11 and xdh keys
+                // https://bugs.openjdk.java.net/browse/JDK-8219381 or https://bugs.openjdk.org/browse/JDK-8213363
+                // set the auxiliary provider as first provider to parse the xdh private key
+                Security.insertProviderAt(JDKTestUtils.getAuxiliaryProvider(), 1);
             }
             Crypto encCrypto = CryptoFactory.getInstance("wss-ecdh.properties");
 
@@ -344,8 +366,11 @@ public class EncryptionTest {
             WSSecEncrypt builder = new WSSecEncrypt(secHeader);
             builder.setUserInfo(certAlias);
             builder.setKeyEncAlgo(WSConstants.KEYWRAP_AES128);
-            builder.setKeyAgreementMethod(WSConstants.AGREEMENT_METHOD_ECDH_ES);
-            builder.setDigestAlgorithm(WSS4JConstants.SHA256);
+            builder.setKeyAgreementMethod(keyAgreementMethod);
+            builder.setKeyDerivationMethod(kdfAlgorithm);
+            if (kdfAlgorithm.equalsIgnoreCase(WSS4JConstants.KEYDERIVATION_CONCATKDF)){
+                builder.setDigestAlgorithm(WSS4JConstants.SHA256);
+            }
             builder.setKeyIdentifierType(WSConstants.SKI_KEY_IDENTIFIER);
 
             LOG.info("Before Encryption ...");
@@ -357,6 +382,7 @@ public class EncryptionTest {
 
             String outputString =
                     XMLUtils.prettyDocumentToString(encryptedDoc);
+
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Encrypted message:");
                 LOG.debug(outputString);
@@ -365,7 +391,98 @@ public class EncryptionTest {
             // Check for algorithms and agreement method element
             assertTrue(outputString.contains(EncryptionConstants._TAG_AGREEMENTMETHOD));
             assertTrue(outputString.contains(WSConstants.KEYWRAP_AES128));
-            assertTrue(outputString.contains(WSConstants.AGREEMENT_METHOD_ECDH_ES));
+            assertTrue(outputString.contains(keyAgreementMethod));
+
+            WSSecurityEngine newEngine = new WSSecurityEngine();
+            WSHandlerResult results =
+                    newEngine.processSecurityHeader(encryptedDoc, null, keystoreCallbackHandler, encCrypto);
+
+            WSSecurityEngineResult actionResult =
+                    results.getActionResults().get(WSConstants.ENCR).get(0);
+            assertNotNull(actionResult);
+        } finally {
+            Security.removeProvider(JDKTestUtils.getAuxiliaryProvider().getName());
+        }
+    }
+
+    /**
+     * Test that encrypt and decrypt a WS-Security envelope.
+     * This test uses the ECDSA-ES algorithm to (wrap) the symmetric key.
+     * <p/>
+     *
+     * @throws Exception Thrown when there is any problem in signing or verification
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "xdh, X25519, http://www.w3.org/2021/04/xmldsig-more#x25519, http://www.w3.org/2001/04/xmlenc#kw-aes128, 128",
+            "xdh, X448, http://www.w3.org/2021/04/xmldsig-more#x448, http://www.w3.org/2001/04/xmlenc#kw-aes128, 128",
+            "ec, secp256r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes128, 128",
+            "ec, secp384r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes128, 128",
+            "ec, secp521r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes128, 128",
+            "xdh, X25519, http://www.w3.org/2021/04/xmldsig-more#x25519, http://www.w3.org/2001/04/xmlenc#kw-aes192, 192",
+            "xdh, X448, http://www.w3.org/2021/04/xmldsig-more#x448, http://www.w3.org/2001/04/xmlenc#kw-aes192, 192",
+            "ec, secp256r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes192, 192",
+            "ec, secp384r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes192, 192",
+            "ec, secp521r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes192, 192",
+            "xdh, X25519, http://www.w3.org/2021/04/xmldsig-more#x25519, http://www.w3.org/2001/04/xmlenc#kw-aes256, 256",
+            "xdh, X448, http://www.w3.org/2021/04/xmldsig-more#x448, http://www.w3.org/2001/04/xmlenc#kw-aes256, 256",
+            "ec, secp256r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes256, 256",
+            "ec, secp384r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes256, 256",
+            "ec, secp521r1, http://www.w3.org/2009/xmlenc11#ECDH-ES, http://www.w3.org/2001/04/xmlenc#kw-aes256, 256",
+    })
+    public void testEncryptionDecryptionWithKeyAgreementAndHKDF(String algorithm, String certAlias, String keyAgreementMethod, String keyWrapAlg, int keySize ) throws Exception {
+        String hkdfMacFunction = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
+        try {
+            if (!JDKTestUtils.isAlgorithmSupportedByJDK(algorithm)) {
+                LOG.info("Add AuxiliaryProvider to execute test with algorithm [{}] and cert alias [{}]", algorithm, certAlias);
+                Security.addProvider(JDKTestUtils.getAuxiliaryProvider());
+            } else if (JDKTestUtils.getJDKVersion() == 11 && algorithm.equals("xdh")) {
+                // workaround for jdk11 and xdh keys
+                // https://bugs.openjdk.java.net/browse/JDK-8219381 or https://bugs.openjdk.org/browse/JDK-8213363
+                // set the auxiliary provider as first provider to parse the xdh private key
+                Security.insertProviderAt(JDKTestUtils.getAuxiliaryProvider(), 1);
+            }
+            Crypto encCrypto = CryptoFactory.getInstance("wss-ecdh.properties");
+
+            Document doc = SOAPUtil.toSOAPPart(SOAPUtil.SAMPLE_SOAP_MSG);
+            WSSecHeader secHeader = new WSSecHeader(doc);
+            secHeader.insertSecurityHeader();
+
+            HKDFParams keyDerivationParameters = new HKDFParams(keySize, hkdfMacFunction);
+            keyDerivationParameters.setInfo("test-key-info".getBytes());
+            keyDerivationParameters.setSalt(UUID.randomUUID().toString().getBytes());
+
+            WSSecEncrypt builder = new WSSecEncrypt(secHeader);
+            builder.setUserInfo(certAlias);
+            builder.setKeyEncAlgo(keyWrapAlg);
+            builder.setKeyAgreementMethod(keyAgreementMethod);
+            builder.setKeyDerivationParameters(keyDerivationParameters);
+
+
+            LOG.info("Before Encryption ...");
+            KeyGenerator keyGen = KeyUtils.getKeyGenerator(WSConstants.AES_128_GCM);
+            SecretKey symmetricKey = keyGen.generateKey();
+
+            Document encryptedDoc = builder.build(encCrypto, symmetricKey);
+            LOG.info("After Encryption ....");
+
+            String outputString =
+                    XMLUtils.prettyDocumentToString(encryptedDoc);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Encrypted message:");
+                LOG.debug(outputString);
+            }
+            assertFalse(outputString.contains("counter_port_type"));
+            // Check for algorithms and agreement method element
+            assertTrue(outputString.contains(EncryptionConstants._TAG_AGREEMENTMETHOD));
+            assertTrue(outputString.contains(EncryptionConstants._TAG_HKDFPARAMS));
+            assertTrue(outputString.contains(EncryptionConstants._TAG_INFO));
+            assertTrue(outputString.contains(EncryptionConstants._TAG_KEYLENGTH+">"+(keySize/8)+"</"));
+            assertTrue(outputString.contains(hkdfMacFunction));
+
+            assertTrue(outputString.contains(keyWrapAlg));
+            assertTrue(outputString.contains(keyAgreementMethod));
 
             WSSecurityEngine newEngine = new WSSecurityEngine();
             WSHandlerResult results =

--- a/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/EncryptionTest.java
+++ b/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/EncryptionTest.java
@@ -448,9 +448,10 @@ public class EncryptionTest {
             WSSecHeader secHeader = new WSSecHeader(doc);
             secHeader.insertSecurityHeader();
 
-            HKDFParams keyDerivationParameters = new HKDFParams(keySize, hkdfMacFunction);
-            keyDerivationParameters.setInfo("test-key-info".getBytes());
-            keyDerivationParameters.setSalt(UUID.randomUUID().toString().getBytes());
+            HKDFParams keyDerivationParameters = HKDFParams.createBuilder(keySize, hkdfMacFunction)
+                    .info("test-key-info".getBytes())
+                    .salt(UUID.randomUUID().toString().getBytes())
+                    .build();
 
             WSSecEncrypt builder = new WSSecEncrypt(secHeader);
             builder.setUserInfo(certAlias);


### PR DESCRIPTION
Purpose of the PR is to implement configuration options for the  Key Derivation Function
with Key Agreement method. For details see the  [WSS-710](https://issues.apache.org/jira/projects/WSS/issues/WSS-710).

Note:  before the merge of the request the PR for dependence: Santuario/xmlsec library  
https://github.com/apache/santuario-xml-security-java/pull/271
must be accepted and library released. 
See the: *parent/pom.xml*: 
`<xmlsec.version>4.0.3-SNAPSHOT</xmlsec.version> `


The code is contributed on behalf of the European Commission’s edelivery project to support [eDelivery AS4 2.0 profile](https://ec.europa.eu/digital-building-blocks/wikis/pages/viewpage.action?pageId=467117621).