### PR TITLE
Fix for WSS-713: Support SubjectConfirmationData for SAML-SV v1

### DIFF
--- a/ws-security-dom/src/test/java/org/apache/wss4j/dom/common/SAML1CallbackHandler.java
+++ b/ws-security-dom/src/test/java/org/apache/wss4j/dom/common/SAML1CallbackHandler.java
@@ -81,6 +81,7 @@ public class SAML1CallbackHandler extends AbstractSAMLCallbackHandler {
                 if (subjectNameIDFormat != null) {
                     subjectBean.setSubjectNameIDFormat(subjectNameIDFormat);
                 }
+                subjectBean.setSubjectConfirmationData(subjectConfirmationData);
                 if (SAML1Constants.CONF_HOLDER_KEY.equals(confirmationMethod)) {
                     try {
                         KeyInfoBean keyInfo = createKeyInfo();


### PR DESCRIPTION
Adding support for `SubjectConfirmationData`-element in case of SAML-SV v1