### PR TITLE
Replace deprecated shibboleth import

### DIFF
--- a/ws-security-common/src/main/java/org/apache/wss4j/common/saml/WSS4JXSBase64BinaryUnmarshaller.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/saml/WSS4JXSBase64BinaryUnmarshaller.java
@@ -19,7 +19,7 @@
 
 package org.apache.wss4j.common.saml;
 
-import net.shibboleth.utilities.java.support.primitive.StringSupport;
+import net.shibboleth.shared.primitive.StringSupport;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.w3c.dom.Text;


### PR DESCRIPTION
The class `net.shibboleth.utilities.java.support.primitive.StringSupport` is deprecated since OpenSAML 5, where they switched from `net.shibboleth.utilities:java-support` to `net.shibboleth:shib-support`. 

Because of that, I frequently get this warning while using wss4j:

> Java class 'net.shibboleth.utilities.java.support.primitive.StringSupport': This will be removed in the next major version of this software; replacement is net.shibboleth.shared.primitive.StringSupport

This PR replaces the deprecated import with the new one.