### PR TITLE
WSS-726 Make EncryptedKeyProcessor.getAsymmetricDecryptedByte overridable

### DIFF
--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/EncryptedKeyProcessor.java
@@ -341,7 +341,19 @@ public class EncryptedKeyProcessor implements Processor {
         return X509Util.getSecretKey(keyInfoChildElement, algorithmURI, data.getCallbackHandler());
     }
 
-    private static byte[] getAsymmetricDecryptedBytes(
+    /**
+     * Initializes the cipher decrypting the encryptedEphemeralKey as indicated by the encryptedKeyTransportMethod
+     * @param data
+     * @param wsDocInfo
+     * @param encryptedKeyTransportMethod
+     * @param encryptedEphemeralKey
+     * @param refList
+     * @param encryptedKeyElement
+     * @param privateKey
+     * @return the decrypted key or, in case of an exception during the decryption, a randomKey
+     * @throws WSSecurityException
+     */
+    protected byte[] getAsymmetricDecryptedBytes(
         RequestData data,
         WSDocInfo wsDocInfo,
         String encryptedKeyTransportMethod,
@@ -508,7 +520,7 @@ public class EncryptedKeyProcessor implements Processor {
      * Generates a random secret key using the algorithm specified in the
      * first DataReference URI
      */
-    private static byte[] getRandomKey(Element refList, WSDocInfo wsDocInfo) throws WSSecurityException {
+    protected static byte[] getRandomKey(Element refList, WSDocInfo wsDocInfo) throws WSSecurityException {
         try {
             String alg = "AES";
             int size = 16;


### PR DESCRIPTION
Allow overriding EncryptedKeyProcessor#getAsymmetricDecryptedByte in order to customize Cipher init and decryption

see https://issues.apache.org/jira/projects/WSS/issues/WSS-726