### PR TITLE
WSS-727 Do not cache SwA attachment References when verifying a Signature

### DIFF
--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/SignatureProcessor.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/SignatureProcessor.java
@@ -419,12 +419,15 @@ public class SignatureProcessor implements Processor {
     }
 
     /**
-     * Equivalent to XMLSignature.validate(context), except that Reference caching is turned off
-     * for SwA attachment References. Caching a Reference makes Santuario retain every octet fed
-     * to the digest, which for an attachment is the whole attachment - and the only consumer of
-     * that copy is Reference.getDigestInputStream(), which WSS4J never calls. The dereferenced
-     * Data of an attachment Reference is not needed either, as buildProtectedRefs recognises
-     * attachment References by their Transform algorithm.
+     * Validates the SignatureValue and then every SignedInfo Reference, as XMLSignature.validate(context)
+     * does, but with Reference caching turned off for SwA attachment References. Unlike
+     * XMLSignature.validate(context), ds:Manifest References are not validated and the result is not
+     * memoised on the XMLSignature.
+     *
+     * Caching a Reference makes Santuario retain every octet fed to the digest, which for an attachment
+     * is the whole attachment - and the only consumer of that copy is Reference.getDigestInputStream(),
+     * which WSS4J never calls. The dereferenced Data of an attachment Reference is not needed either,
+     * as buildProtectedRefs recognises attachment References by their Transform algorithm.
      */
     private boolean validateSignature(XMLSignature xmlSignature, XMLValidateContext context)
         throws XMLSignatureException {

--- a/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/SignatureProcessor.java
+++ b/ws-security-dom/src/main/java/org/apache/wss4j/dom/processor/SignatureProcessor.java
@@ -40,6 +40,7 @@ import javax.xml.crypto.dsig.SignedInfo;
 import javax.xml.crypto.dsig.Transform;
 import javax.xml.crypto.dsig.XMLObject;
 import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.crypto.dsig.XMLSignatureException;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 import javax.xml.crypto.dsig.XMLValidateContext;
 import javax.xml.crypto.dsig.dom.DOMValidateContext;
@@ -378,7 +379,7 @@ public class SignatureProcessor implements Processor {
 
             setElementsOnContext(xmlSignature, (DOMValidateContext)context, data, wsDocInfo);
 
-            boolean signatureOk = xmlSignature.validate(context);
+            boolean signatureOk = validateSignature(xmlSignature, context);
             if (signatureOk) {
                 return xmlSignature;
             }
@@ -394,6 +395,11 @@ public class SignatureProcessor implements Processor {
                     xmlSignature.getSignedInfo().getReferences().iterator();
                 while (referenceIterator.hasNext()) {
                     Reference reference = (Reference)referenceIterator.next();
+                    // References that validateSignature did not reach are validated here for the
+                    // first time - all of them when the SignatureValue itself failed - so keep
+                    // attachment caching off for those too
+                    context.setProperty("javax.xml.crypto.dsig.cacheReference",
+                                        !isAttachmentReference(reference));
                     boolean referenceValidationCheck = reference.validate(context);
                     String id = reference.getId();
                     if (id == null) {
@@ -410,6 +416,45 @@ public class SignatureProcessor implements Processor {
             );
         }
         throw new WSSecurityException(WSSecurityException.ErrorCode.FAILED_CHECK);
+    }
+
+    /**
+     * Equivalent to XMLSignature.validate(context), except that Reference caching is turned off
+     * for SwA attachment References. Caching a Reference makes Santuario retain every octet fed
+     * to the digest, which for an attachment is the whole attachment - and the only consumer of
+     * that copy is Reference.getDigestInputStream(), which WSS4J never calls. The dereferenced
+     * Data of an attachment Reference is not needed either, as buildProtectedRefs recognises
+     * attachment References by their Transform algorithm.
+     */
+    private boolean validateSignature(XMLSignature xmlSignature, XMLValidateContext context)
+        throws XMLSignatureException {
+        if (!xmlSignature.getSignatureValue().validate(context)) {
+            return false;
+        }
+        try {
+            for (Object referenceObject : xmlSignature.getSignedInfo().getReferences()) {
+                Reference reference = (Reference)referenceObject;
+                context.setProperty("javax.xml.crypto.dsig.cacheReference",
+                                    !isAttachmentReference(reference));
+                if (!reference.validate(context)) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            context.setProperty("javax.xml.crypto.dsig.cacheReference", Boolean.TRUE);
+        }
+    }
+
+    private static boolean isAttachmentReference(Reference reference) {
+        for (Object transformObject : reference.getTransforms()) {
+            String algorithm = ((Transform)transformObject).getAlgorithm();
+            if (WSConstants.SWA_ATTACHMENT_CONTENT_SIG_TRANS.equals(algorithm)
+                || WSConstants.SWA_ATTACHMENT_COMPLETE_SIG_TRANS.equals(algorithm)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -531,6 +576,13 @@ public class SignatureProcessor implements Processor {
                 Element se = dereferenceSTR(doc, siRef, requestData, wsDocInfo);
                 // If an STR Transform is not used then just find the cached element
                 boolean attachment = false;
+                if (se == null && isAttachmentReference(siRef)) {
+                    // Attachment References are not cached, so recognise them by their
+                    // Transform algorithm rather than by their dereferenced Data
+                    se = doc.createElementNS("http://docs.oasis-open.org/wss/oasis-wss-SwAProfile-1.1",
+                                             "attachment");
+                    attachment = true;
+                }
                 if (se == null) {
                     Data dereferencedData = siRef.getDereferencedData();
                     if (dereferencedData instanceof NodeSetData) {

--- a/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/AttachmentTest.java
+++ b/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/AttachmentTest.java
@@ -50,9 +50,11 @@ import org.apache.wss4j.common.util.KeyUtils;
 import org.apache.wss4j.common.util.SOAPUtil;
 import org.apache.wss4j.common.util.XMLUtils;
 import org.apache.wss4j.dom.WSConstants;
+import org.apache.wss4j.dom.WSDataRef;
 import org.apache.wss4j.dom.common.KeystoreCallbackHandler;
 import org.apache.wss4j.dom.engine.WSSConfig;
 import org.apache.wss4j.dom.engine.WSSecurityEngine;
+import org.apache.wss4j.dom.engine.WSSecurityEngineResult;
 import org.apache.wss4j.dom.handler.RequestData;
 import org.apache.wss4j.dom.handler.WSHandlerResult;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,7 @@ import org.w3c.dom.NodeList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -147,6 +150,60 @@ public class AttachmentTest {
         byte[] attachmentBytes = readInputStream(responseAttachment.getSourceStream());
         assertTrue(Arrays.equals(attachmentBytes, SOAPUtil.SAMPLE_SOAP_MSG.getBytes(StandardCharsets.UTF_8)));
         assertEquals("text/xml", responseAttachment.getMimeType());
+    }
+
+    /**
+     * The WSDataRef of a signed attachment must be flagged as an attachment and carry the
+     * synthesised SwA "attachment" element. Attachment References are not cached during
+     * validation, so this is derived from the Reference's Transform algorithm.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testXMLAttachmentContentSignatureDataRef() throws Exception {
+        Document doc = SOAPUtil.toSOAPPart(SOAPUtil.SAMPLE_SOAP_MSG);
+        WSSecHeader secHeader = new WSSecHeader(doc);
+        secHeader.insertSecurityHeader();
+
+        WSSecSignature builder = new WSSecSignature(secHeader);
+        builder.setUserInfo("16c73ab6-b892-458f-abf5-2f875f74882e", "security");
+
+        builder.getParts().add(new WSEncryptionPart("Body", "http://schemas.xmlsoap.org/soap/envelope/", "Content"));
+        builder.getParts().add(new WSEncryptionPart("cid:Attachments", "Content"));
+
+        final String attachmentId = UUID.randomUUID().toString();
+        final Attachment attachment = new Attachment();
+        attachment.setMimeType("text/xml");
+        attachment.addHeaders(getHeaders(attachmentId));
+        attachment.setId(attachmentId);
+        attachment.setSourceStream(new ByteArrayInputStream(SOAPUtil.SAMPLE_SOAP_MSG.getBytes(StandardCharsets.UTF_8)));
+
+        builder.setAttachmentCallbackHandler(
+            new AttachmentCallbackHandler(Collections.singletonList(attachment)));
+        Document signedDoc = builder.build(crypto);
+
+        WSHandlerResult results =
+            verify(signedDoc, new AttachmentCallbackHandler(Collections.singletonList(attachment)));
+
+        WSSecurityEngineResult actionResult =
+            results.getActionResults().get(WSConstants.SIGN).get(0);
+        List<WSDataRef> refs =
+            (List<WSDataRef>)actionResult.get(WSSecurityEngineResult.TAG_DATA_REF_URIS);
+        assertEquals(2, refs.size());
+
+        WSDataRef attachmentRef = null;
+        for (WSDataRef ref : refs) {
+            if (ref.isAttachment()) {
+                attachmentRef = ref;
+            }
+        }
+        assertNotNull(attachmentRef);
+        assertEquals("cid:" + attachmentId, attachmentRef.getWsuId());
+        Element protectedElement = attachmentRef.getProtectedElement();
+        assertEquals("attachment", protectedElement.getLocalName());
+        assertEquals("http://docs.oasis-open.org/wss/oasis-wss-SwAProfile-1.1",
+                     protectedElement.getNamespaceURI());
+        assertTrue(attachmentRef.getTransformAlgorithms()
+                   .contains(WSConstants.SWA_ATTACHMENT_CONTENT_SIG_TRANS));
     }
 
     @Test

--- a/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/AttachmentTest.java
+++ b/ws-security-dom/src/test/java/org/apache/wss4j/dom/message/AttachmentTest.java
@@ -154,8 +154,10 @@ public class AttachmentTest {
 
     /**
      * The WSDataRef of a signed attachment must be flagged as an attachment and carry the
-     * synthesised SwA "attachment" element. Attachment References are not cached during
-     * validation, so this is derived from the Reference's Transform algorithm.
+     * synthesised SwA "attachment" element. buildProtectedRefs derives this from the Reference's
+     * Transform algorithm rather than from the dereferenced Data, so these assertions hold whether
+     * or not the attachment Reference was cached during validation. Non-caching itself is not
+     * verified here: its only observable effect is heap usage.
      */
     @Test
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/WSS-727

## The Problem

When you verify a SOAP message with a signed SwA attachment, it needs about 2.3x the attachment's size in heap memory. This happens even if the attachment is already on disk or if you provide a streaming source. Compare that to *signing* the same message, which only needs ~20 MB consistently. That's a huge difference.

The culprit is a single flag in `SignatureProcessor.verifyXMLSignature()`:

```java
XMLValidateContext context = new DOMValidateContext(key, elem);
context.setProperty("javax.xml.crypto.dsig.cacheReference", Boolean.TRUE);
```

This flag tells Santuario to cache stuff, but it's a blunt instrument. In `DOMReference.transform()` (xmlsec 4.0.4), it flips on *two* separate caches that have nothing to do with each other:

```java
Boolean cache = (Boolean) context.getProperty("javax.xml.crypto.dsig.cacheReference");
if (cache != null && cache) {
    this.derefData = copyDerefData(dereferencedData);
    dos = new DigesterOutputStream(md, true);   // <-- keeps every byte fed to the digest
} else {
    dos = new DigesterOutputStream(md);
}
```

The two caches:
1. **Dereferenced data** - cheap, and WSS4J actually needs this. It's used by `buildProtectedRefs()` to figure out what each Reference covered.
2. **Pre-digested input** - the problem. The `DigesterOutputStream` buffers it all in an `UnsyncByteArrayOutputStream`, which doubles in size as it grows, then copies the whole thing again in `getInputStream()`.

For attachments, `AttachmentContentSignatureTransform` feeds the attachment directly into that stream. So a 200 MB attachment ends up consuming a 256 MB backing array *plus* a 200 MB copy - ~456 MB live at once. This buffered copy is useless: the only thing that reads it is `Reference.getDigestInputStream()`, and WSS4J never calls that.

```
java.lang.OutOfMemoryError: Java heap space
    at org.apache.xml.security.utils.UnsyncByteArrayOutputStream.expandSize(UnsyncByteArrayOutputStream.java:113)
    at org.apache.jcp.xml.dsig.internal.DigesterOutputStream.write(DigesterOutputStream.java:83)
    at org.apache.wss4j.dom.transform.AttachmentContentSignatureTransform.processAttachment(AttachmentContentSignatureTransform.java:218)
    ...
```

## The Fix

The solution has two parts:

1. **Replace `xmlSignature.validate(context)` with an explicit loop.** Instead of one call, we do:
   - Check the `SignatureValue`
   - Validate each `Reference` individually
   - For attachment References (identified by their Transform algorithm), toggle off `cacheReference`
   
2. **Update `buildProtectedRefs()` to recognize attachments by their Transform algorithm.** This is essential. With caching off, `getDereferencedData()` returns `null`, so toggling the flag alone would break every signed attachment with `FAILED_CHECK`. The fix keeps `buildProtectedRefs()` working: it still produces the same `WSDataRef` with the synthesised `<attachment>` element and `setAttachment(true)`.

### Why this preserves the existing behavior:

- **The flag is read per-Reference at transform time**, so we can toggle it between `Reference.validate()` calls without issues.

- **`Reference.validate()` caches its result**, so when debug logging re-validates a Reference we already checked, it just uses the cached status, it doesn't re-transform. References the loop hasn't reached yet get validated there, and the caching rule applies to them too. This matters more than it sounds: if the SignatureValue check fails (a common failure), we bail out before validating any References. Without this, turning on debug logging to diagnose the failure would buffer every signed attachment on that message, leading to the very OutOfMemoryError we're fixing. The old code did exactly this.

- **Non-attachment References still cache**, so element recovery, the STR-dereference path (WSS-222), and the anti-wrapping checks all keep working. We restore the flag to `TRUE` when we're done.

- **The explicit loop is fully equivalent to `DOMXMLSignature.validate()`**: Manifest validation only runs if `org.jcp.xml.dsig.validateManifests` is set (WSS4J never sets it), and the XMLSignature's cached validation status is never read because the object doesn't escape `SignatureProcessor`.

- **The short-circuit semantics match the old behavior** - still bail on first failure.

- **`ws-security-stax` doesn't use this property**, so no impact there.

## Testing

A new test, `AttachmentTest.testXMLAttachmentContentSignatureDataRef`, verifies that the `WSDataRef` for a signed attachment still has `isAttachment()` set and still carries the synthesised SwA `attachment` element. This ensures the `buildProtectedRefs()` change does what it's supposed to.

### Memory measurements

200 MB attachment from the WSS-727 repro; source stream is mark/reset-capable so it contributes no heap

| Scenario | Heap limit | Result |
|----------|-----------|---------|
| Sign 200 MB attachment | 256m | OK, peak 17 MB |
| Verify 200 MB attachment (before fix) | 256m | OutOfMemoryError |
| Verify 200 MB attachment (before fix) | 512m | OK, peak 466 MB |
| Verify 200 MB attachment (after fix) | 256m | OK, peak 22 MB |

## Notes

**History:** The `cacheReference` flag has been there since the WSS4J 2.0 rename (commit f647a91bd), so the bug affects 2.x and 3.x as well. Tested on 4.0.1 and current master.

**The bigger picture:** The digest input buffer also costs ~3.2x the signed content for regular element References (minimum -Xmx: 160m vs 96m for a 20 MB Body, or 288m vs 160m for 40 MB). The key difference is asymptotic: element content is already in the DOM, so the cache is a constant-factor overhead you can outrun by raising heap; attachment content is streaming and otherwise never in memory, so the cache turns constant-heap streaming into O(attachment-size) that no fixed heap covers. This fix is narrowly scoped to SwA attachments - the only case with no caller-side workaround.

For element and STR References, the dereferenced data is the authoritative record of what was digested and is essential for `WSDataRef` and the anti-wrapping checks. You can't just disable caching for those without losing that data. A proper fix for all Reference types would require Santuario to expose *separate* properties for the two caches instead of one toggle for both - that would let `buildProtectedRefs()` fetch the dereferenced data without buffering the digest input. That's a design change upstream that would need a new Santuario release.

**Related:** WSS-638 is about `processAttachment()` buffering non-mark-capable source streams via `BufferedInputStream.mark(Integer.MAX_VALUE)`. That one still happens on both sign and verify, and it's not fixed here. The workaround is to supply a disk-backed, mark-capable stream. The bug we're fixing had no workaround because the digest-side cache retained the attachment regardless of how the stream behaved.
