### PR TITLE
Use provider-neutral X.509 key identifier parsing

### DIFF
--- a/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/BouncyCastleUtils.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/BouncyCastleUtils.java
@@ -21,23 +21,38 @@ package org.apache.wss4j.common.crypto;
 
 import java.security.cert.X509Certificate;
 
-import org.bouncycastle.asn1.ASN1OctetString;
-import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
-import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
+import org.apache.wss4j.common.ext.WSSecurityException;
 
+/**
+ * Parses X.509 key identifier extensions. The historical class name is retained for binary
+ * compatibility, but the implementation is provider-neutral.
+ */
 public final class BouncyCastleUtils {
+
+    private static final int TYPE_CONTEXT_SPECIFIC_0 = 0x80;
 
     private BouncyCastleUtils() {
         // complete
     }
 
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
     public static byte[] getAuthorityKeyIdentifierBytes(X509Certificate cert) {
         byte[] extensionValue = cert.getExtensionValue("2.5.29.35"); //NOPMD
         if (extensionValue != null) {
-            byte[] octets = ASN1OctetString.getInstance(extensionValue).getOctets();
-            AuthorityKeyIdentifier authorityKeyIdentifier =
-                AuthorityKeyIdentifier.getInstance(octets);
-            return authorityKeyIdentifier.getKeyIdentifier();
+            try {
+                DERDecoder extension = unwrapExtensionValue(extensionValue);
+                extension.expect(DERDecoder.TYPE_SEQUENCE);
+                DERDecoder authorityKeyIdentifier =
+                    new DERDecoder(extension.getBytes(extension.getLength()));
+                if (!authorityKeyIdentifier.hasRemaining()
+                    || !authorityKeyIdentifier.test((byte)TYPE_CONTEXT_SPECIFIC_0)) {
+                    return null;
+                }
+                authorityKeyIdentifier.expect(TYPE_CONTEXT_SPECIFIC_0);
+                return authorityKeyIdentifier.getBytes(authorityKeyIdentifier.getLength());
+            } catch (WSSecurityException ex) {
+                throw new IllegalArgumentException("Invalid AuthorityKeyIdentifier extension", ex);
+            }
         }
         return new byte[0];
     }
@@ -45,15 +60,20 @@ public final class BouncyCastleUtils {
     public static byte[] getSubjectKeyIdentifierBytes(X509Certificate cert) {
         byte[] extensionValue = cert.getExtensionValue("2.5.29.14"); //NOPMD
         if (extensionValue != null) {
-            byte[] subjectOctets =
-                ASN1OctetString.getInstance(extensionValue).getOctets();
-            SubjectKeyIdentifier subjectKeyIdentifier =
-                SubjectKeyIdentifier.getInstance(subjectOctets);
-            return subjectKeyIdentifier.getKeyIdentifier();
+            try {
+                DERDecoder subjectKeyIdentifier = unwrapExtensionValue(extensionValue);
+                subjectKeyIdentifier.expect(DERDecoder.TYPE_OCTET_STRING);
+                return subjectKeyIdentifier.getBytes(subjectKeyIdentifier.getLength());
+            } catch (WSSecurityException ex) {
+                throw new IllegalArgumentException("Invalid SubjectKeyIdentifier extension", ex);
+            }
         }
         return new byte[0];
     }
 
+    private static DERDecoder unwrapExtensionValue(byte[] extensionValue) throws WSSecurityException {
+        DERDecoder extension = new DERDecoder(extensionValue);
+        extension.expect(DERDecoder.TYPE_OCTET_STRING);
+        return new DERDecoder(extension.getBytes(extension.getLength()));
+    }
 }
-
-

--- a/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/DERDecoder.java
+++ b/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/DERDecoder.java
@@ -48,7 +48,7 @@ public class DERDecoder {
     /** DER type identifier for ASN.1 "OBJECT IDENTIFIER" value. */
     public static final byte TYPE_OBJECT_IDENTIFIER = 0x06;
 
-    private byte[] arr;
+    private final byte[] arr;
     private int pos;
 
     /**
@@ -78,13 +78,22 @@ public class DERDecoder {
     }
 
     /**
+     * Return whether unread bytes remain in this decoder.
+     *
+     * @return true if at least one byte remains.
+     */
+    public boolean hasRemaining() {
+        return pos < arr.length;
+    }
+
+    /**
      * Advance the current position by the given number of bytes.
      *
      * @param length the number of bytes to skip.
-     * @throws WSSecurityException if length is negative.
+     * @throws WSSecurityException if length is negative or exceeds the remaining data.
      */
     public void skip(int length) throws WSSecurityException {
-        if (length < 0) {
+        if (length < 0 || length > arr.length - pos) {
             throw new WSSecurityException(
                     WSSecurityException.ErrorCode.UNSUPPORTED_SECURITY_TOKEN,
                     "noSKIHandling",
@@ -175,16 +184,25 @@ public class DERDecoder {
             len = arr[pos++];
         } else {
             int nbytes = arr[pos++] & 0x7F;
-            if (pos + nbytes > arr.length) {
+            if (nbytes == 0) {
+                return -1;
+            }
+            if (nbytes > 4 || nbytes > arr.length - pos) {
                 throw new WSSecurityException(
                         WSSecurityException.ErrorCode.UNSUPPORTED_SECURITY_TOKEN,
-                        "noSKIHandling",
-                        new Object[] {"Invalid DER format"}
+                        "noSKIHandling", new Object[] {"Unsupported DER format"}
                 );
             }
             byte[] lenBytes = new byte[nbytes];
             System.arraycopy(arr, pos, lenBytes, 0, lenBytes.length);
-            len = new BigInteger(1, lenBytes).intValue();
+            BigInteger bigLength = new BigInteger(1, lenBytes);
+            if (bigLength.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0) {
+                throw new WSSecurityException(
+                        WSSecurityException.ErrorCode.UNSUPPORTED_SECURITY_TOKEN,
+                        "noSKIHandling", new Object[] {"Unsupported DER format"}
+                );
+            }
+            len = bigLength.intValue();
             pos += nbytes;
         }
         return len;
@@ -201,18 +219,16 @@ public class DERDecoder {
      *         length is negative.
      */
     public byte[] getBytes(int length) throws WSSecurityException {
-        if (pos + length > arr.length) {
+        if (length < 0) {
             throw new WSSecurityException(
                     WSSecurityException.ErrorCode.UNSUPPORTED_SECURITY_TOKEN,
-                    "noSKIHandling",
-                    new Object[] {"Invalid DER format"}
-             );
-        } else if (length < 0) {
-            throw new WSSecurityException(
-                    WSSecurityException.ErrorCode.UNSUPPORTED_SECURITY_TOKEN,
-                    "noSKIHandling",
-                    new Object[] {"Unsupported DER format"}
+                    "noSKIHandling", new Object[] {"Unsupported DER format"}
             );
+        } else if (length > arr.length - pos) {
+            throw new WSSecurityException(
+                    WSSecurityException.ErrorCode.UNSUPPORTED_SECURITY_TOKEN,
+                    "noSKIHandling", new Object[] {"Invalid DER format"}
+             );
         }
         byte[] value = new byte[length];
         System.arraycopy(arr, pos, value, 0, length);

--- a/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/AuthorityKeyIdentifierTest.java
+++ b/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/AuthorityKeyIdentifierTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This is a test for extracting AuthorityKeyIdentifier/SubjectKeyIdentifier information from
- * the certs using BouncyCastle.
+ * the certs using the provider-neutral DER decoder.
  */
 public class AuthorityKeyIdentifierTest {
 

--- a/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/DERDecoderTest.java
+++ b/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/DERDecoderTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.common.crypto;
+
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DERDecoderTest {
+
+    @Test
+    public void testShortLengthValue() throws Exception {
+        DERDecoder decoder = new DERDecoder(new byte[] {DERDecoder.TYPE_OCTET_STRING, 0x02, 0x01, 0x02});
+        decoder.expect(DERDecoder.TYPE_OCTET_STRING);
+        assertEquals(2, decoder.getLength());
+        assertArrayEquals(new byte[] {0x01, 0x02}, decoder.getBytes(2));
+        assertFalse(decoder.hasRemaining());
+    }
+
+    @Test
+    public void testIndefiniteLength() throws Exception {
+        DERDecoder decoder = new DERDecoder(new byte[] {DERDecoder.TYPE_SEQUENCE, (byte)0x80});
+        decoder.expect(DERDecoder.TYPE_SEQUENCE);
+        assertEquals(-1, decoder.getLength());
+    }
+
+    @Test
+    public void testRejectsLengthLargerThanInteger() throws Exception {
+        DERDecoder decoder = new DERDecoder(
+            new byte[] {DERDecoder.TYPE_SEQUENCE, (byte)0x84, (byte)0x80, 0x00, 0x00, 0x00}
+        );
+        decoder.expect(DERDecoder.TYPE_SEQUENCE);
+        assertThrows(WSSecurityException.class, decoder::getLength);
+    }
+
+    @Test
+    public void testRejectsReadsAndSkipsBeyondRemainingData() throws Exception {
+        DERDecoder decoder = new DERDecoder(new byte[] {0x01});
+        assertTrue(decoder.hasRemaining());
+        assertThrows(WSSecurityException.class, () -> decoder.getBytes(Integer.MAX_VALUE));
+        assertThrows(WSSecurityException.class, () -> decoder.skip(Integer.MAX_VALUE));
+    }
+}

--- a/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/KeyIdentifierWithoutBCProbe.java
+++ b/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/KeyIdentifierWithoutBCProbe.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.common.crypto;
+
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+import org.apache.wss4j.common.util.Loader;
+
+/** Invoked through an isolated class loader by {@link KeyIdentifierWithoutBCTest}. */
+public final class KeyIdentifierWithoutBCProbe {
+
+    private KeyIdentifierWithoutBCProbe() {
+        // complete
+    }
+
+    public static boolean verify() throws Exception {
+        X509Certificate cert = loadCertificate("keys/wss40.jks", "security", "wss40");
+        X509Certificate caCert = loadCertificate("keys/wss40CA.jks", "security", "wss40CA");
+        return Arrays.equals(
+            BouncyCastleUtils.getAuthorityKeyIdentifierBytes(cert),
+            BouncyCastleUtils.getSubjectKeyIdentifierBytes(caCert)
+        );
+    }
+
+    private static X509Certificate loadCertificate(String path, String password, String alias) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        ClassLoader loader = Loader.getClassLoader(KeyIdentifierWithoutBCProbe.class);
+        try (InputStream input = Merlin.loadInputStream(loader, path)) {
+            keyStore.load(input, password.toCharArray());
+        }
+        return (X509Certificate)keyStore.getCertificate(alias);
+    }
+}

--- a/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/KeyIdentifierWithoutBCTest.java
+++ b/ws-security-common/src/test/java/org/apache/wss4j/common/crypto/KeyIdentifierWithoutBCTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.common.crypto;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Verifies X.509 SKI and AKI extraction while Bouncy Castle is hidden. */
+public class KeyIdentifierWithoutBCTest {
+
+    private static final String PROBE_CLASS = KeyIdentifierWithoutBCProbe.class.getName();
+
+    @Test
+    public void testKeyIdentifierExtractionWithoutBC() throws Exception {
+        URL[] urls = {
+            new File("target/classes").toURI().toURL(),
+            new File("target/test-classes").toURI().toURL()
+        };
+        try (URLClassLoader classLoader = new URLClassLoader(urls, getClass().getClassLoader()) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.startsWith("org.bouncycastle.")) {
+                    throw new ClassNotFoundException("Bouncy Castle deliberately hidden from test class loader");
+                }
+
+                if (name.equals(BouncyCastleUtils.class.getName())
+                    || name.equals(DERDecoder.class.getName())
+                    || name.equals(PROBE_CLASS)) {
+                    synchronized (getClassLoadingLock(name)) {
+                        Class<?> loadedClass = findLoadedClass(name);
+                        if (loadedClass == null) {
+                            loadedClass = findClass(name);
+                        }
+                        if (resolve) {
+                            resolveClass(loadedClass);
+                        }
+                        return loadedClass;
+                    }
+                }
+
+                return super.loadClass(name, resolve);
+            }
+        }) {
+            assertThrows(ClassNotFoundException.class,
+                () -> classLoader.loadClass("org.bouncycastle.asn1.ASN1Primitive"));
+
+            Class<?> probeClass = Class.forName(PROBE_CLASS, true, classLoader);
+            assertTrue((Boolean)probeClass.getMethod("verify").invoke(null));
+        }
+    }
+}


### PR DESCRIPTION
## What this changes

- Replaces the direct Bouncy Castle ASN.1 use for X.509 AuthorityKeyIdentifier and SubjectKeyIdentifier extraction with WSS4J's existing `DERDecoder`.
- Retains the historical `BouncyCastleUtils` class name and all public method signatures for binary/source compatibility.
- Hardens `DERDecoder` against out-of-bounds skips/reads and overflowing or unsupported length fields while making its documented indefinite-length result explicit.

## Compatibility

The existing return behavior is preserved:

- a missing extension returns an empty byte array;
- an AuthorityKeyIdentifier extension without a key identifier returns `null`;
- malformed extension data still surfaces as `IllegalArgumentException` from `BouncyCastleUtils`.

This does not remove WSS4J's optional BC provider support or change its SAML/OpenSAML dependencies. It removes the direct BC linkage from the standard X.509 key-identifier path, which is useful independently and is a prerequisite for downstream applications that want a provider-neutral runtime.

## Follow-up boundary

I also traced the remaining dependency graph rather than treating this PR as a complete BC-removal change. `ws-security-common` has no direct `org.cryptacular` source imports, but it contains the SAML integration and therefore has hard OpenSAML plus Cryptacular dependencies; current OpenSAML modules also depend on BC. A genuinely lean non-SAML runtime would consequently need a module boundary (for example, moving the SAML/OpenSAML integration to a dedicated artifact) or an explicitly documented optional feature arrangement, most safely in a major release. I have kept that architectural/backward-compatibility decision out of this focused PR and would be happy to follow the maintainers' preferred direction.

## Verification

- `mvn -pl ws-security-common -am verify` passed for the full three-project reactor.
- Full `ws-security-common` suite: 4,088 tests, 0 failures/errors/skips.
- Existing real-certificate AKI/SKI extraction and `MerlinAKI` trust verification remain green.
- Added focused bounds/length tests for `DERDecoder`.
- Added an isolated classloader test that loads real `wss40` and CA JKS certificates, deliberately hides `org.bouncycastle.*`, and verifies the certificate AKI equals the issuer SKI.
- PMD, Checkstyle, compiler/Error Prone, packaging, and CycloneDX steps pass.
- Production source has no direct `org.bouncycastle` imports, and compiled `ws-security-common` classes contain no `org/bouncycastle` bytecode references.
